### PR TITLE
#3 Add Computations for ICU Cases and Loses in USD

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,7 +23,11 @@
       "func-names":"off",
       "object-shorthand":"off",
       "class-methods-use-this":"off",
-      "no-console":"off"
+      "no-console":"off",
+      "comma-spacing": ["error", { "before": false, "after": true }],
+      "object-curly-newline":["error", "never", { "objectsInObjects": true }],
+      "object-curly-spacing":["error", "never", { "objectsInObjects": true }]
+
   
     }
   }

--- a/src/JSmodules/main.js
+++ b/src/JSmodules/main.js
@@ -1,7 +1,11 @@
 import inputData from './data';
 
 const covid19ImpactEstimator = (data) => {
-  const { reportedCases, totalHospitalBeds } = data;
+  const {
+    reportedCases,
+    totalHospitalBeds,
+    region: { avgDailyIncomeUSD },
+  } = data;
   const impact = {
     currentlyInfected: reportedCases * 10,
     infectionsByRequestedTime: (requestedTimeInDays) => {
@@ -16,6 +20,16 @@ const covid19ImpactEstimator = (data) => {
       return (
         impact.severeCasesByRequestedTime(requestedTimeInDays) -
         Math.floor(0.35 * ((100 / 95) * totalHospitalBeds))
+      );
+    },
+    casesForICUByRequestedTime: (requestedTimeInDays) => {
+      return (5 / 100) * impact.infectionsByRequestedTime(requestedTimeInDays);
+    },
+    dollarsInFlight: (requestedTimeInDays) => {
+      return Math.floor(
+        (avgDailyIncomeUSD *
+          impact.infectionsByRequestedTime(requestedTimeInDays)) /
+          30
       );
     },
   };
@@ -34,6 +48,18 @@ const covid19ImpactEstimator = (data) => {
       return (
         severeImpact.severeCasesByRequestedTime(requestedTimeInDays) -
         Math.floor(0.35 * ((100 / 95) * totalHospitalBeds))
+      );
+    },
+    casesForICUByRequestedTime: (requestedTimeInDays) => {
+      return (
+        (5 / 100) * severeImpact.infectionsByRequestedTime(requestedTimeInDays)
+      );
+    },
+    dollarsInFlight: (requestedTimeInDays) => {
+      return Math.floor(
+        (avgDailyIncomeUSD *
+          severeImpact.infectionsByRequestedTime(requestedTimeInDays)) /
+          30
       );
     },
   };


### PR DESCRIPTION
#### What does this PR do?
Add computation for casesForICUByRequestedTime and dollarInFlight for both normal impact and severe impact scenarios.
#### Description of Task to be completed?
Create and test casesForICUByRequestedTime and dollarInFlight functions, and make them part of the estimation output.
#### How would this be manually tested?

1. Given 28 days period, casesForICUByRequestedTime function should compute 5% of the infections over that period to arrive at;

- normal impact: 172,544 cases

- severe impact: 862,720 cases

2. Given 28 days period, dollarsInFlight function should compute total lost income in USD of the total infections over that period to arrive at;

- normal impact: $ 575,146

- severe impact: $ 2,875,733

#### What are the relevant pivotal tracker stories?
#3